### PR TITLE
v1.0.4

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -32,7 +32,7 @@
 
 ## Converter
 
-1. Does the converter require Internet connections?
+1. Does the converter require an Internet connections?
 
     An internet connection is only required for currency conversions and nothing else. All other conversions should work fine without it.
 
@@ -40,11 +40,16 @@
 
     Yes, this is because when you enter data, an API request is made to [exchangeratehost](https://exchangerate.host/#/). So this depends upon your internet connection speed, the value entered, the currencies selected on both sides.
 
-3. Is there a limit to the unit you can type?
+3. Does the converter remember the last tab and units I used?
+
+    Yes, the converter does remember the last tab you opened if you have enabled 'Use Recent Tab' in Settings. 
+    However, the units are not remembered since there are some issues with spinner(combobox/unit selector).
+
+4. Is there a limit to the unit you can type?
 
     Currently we haven't encountered such a thing.
 
-4. I have an issue where there is 'no result/I can't type in the text input' especially on currency conversion tab.
+5. I have an issue where there is 'no result/I can't type in the text input' especially on currency conversion tab.
 
     This is a very rare issue that is encountered on some devices although everything works fine on other devices running the same Android version, updates, etc.
 
@@ -63,7 +68,7 @@
 
 2. How do I donate?
 
-    Go to https://github.com/Yet-Zio/yetCalc/blob/main/DONATE.md\
+    Go to https://github.com/Yet-Zio/yetCalc/blob/main/DONATE.md
     or Settings -> Tap Donate
     takes you to the same link anyways.
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "yetzio.yetcalc"
         minSdk 21
         targetSdk 33
-        versionCode 4
-        versionName "1.0.3"
+        versionCode 5
+        versionName "1.0.4"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/yetzio/yetcalc/MainActivity.kt
+++ b/app/src/main/java/yetzio/yetcalc/MainActivity.kt
@@ -1299,6 +1299,7 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, AdapterView.OnIt
                     Calc.addToHistory(textexpression.text.toString(), textres.text.toString())
                     textexpression.setText(textres.text)
                     textres.setText("")
+                    textexpression.setSelection(textexpression.length())
                     result = textres.text.toString()
                 }
             }

--- a/app/src/main/java/yetzio/yetcalc/component/Calculator.kt
+++ b/app/src/main/java/yetzio/yetcalc/component/Calculator.kt
@@ -9,6 +9,7 @@ class Calculator{
     var almostInt = true
     var precision = "Default precision"
     val m_history = History()
+    val MAXREP = 9999999
 
     fun calculate(expr: String): String {
         val ncr = Function("nCr(n, r) = nCk(n, r)")
@@ -39,7 +40,7 @@ class Calculator{
 
         val e = Expression(expr, grad, npr, ncr)
 
-        return if(e.calculate() > Long.MAX_VALUE){
+        return if(e.calculate() > MAXREP){
             e.calculate().toString()
         }
         else if(e.calculate() % 1.0 == 0.0){

--- a/app/src/main/java/yetzio/yetcalc/model/ConverterPref.kt
+++ b/app/src/main/java/yetzio/yetcalc/model/ConverterPref.kt
@@ -1,0 +1,3 @@
+package yetzio.yetcalc.model
+
+data class ConverterPref(var tabnum: Int)

--- a/app/src/main/java/yetzio/yetcalc/views/fragments/adapters/ViewPagerAdapter.kt
+++ b/app/src/main/java/yetzio/yetcalc/views/fragments/adapters/ViewPagerAdapter.kt
@@ -4,7 +4,6 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.viewpager2.adapter.FragmentStateAdapter
 
-
 class ViewPagerAdapter(fa: FragmentActivity): FragmentStateAdapter(fa){
     var mFragList = ArrayList<Fragment>()
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <resources>
     <string name="author_name">Yet Zio</string>
     <string name="app_name">yetCalc</string>
-    <string name="VERSION_NUM">1.0.3</string>
+    <string name="VERSION_NUM">1.0.4</string>
     <string name="app_descrp">Yet another calculator by Yet Zio</string>
     <string name="ghbtext">View on GitHub</string>
     <string name="app_details">Free and open source software\nLicensed under the BSD-3-Clause license.</string>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -29,6 +29,16 @@
 
     </PreferenceCategory>
 
+    <PreferenceCategory app:title="Converter">
+
+        <SwitchPreferenceCompat
+            app:key="lastusedtabkey"
+            app:summary="Open the last used section by default."
+            app:title="Use Recent Tab"
+            app:defaultValue="true" />
+
+    </PreferenceCategory>
+
     <PreferenceCategory app:title="App">
         <Preference
             app:title="Donate"

--- a/fastlane/metadata/android/en-US/changelogs/5.txt
+++ b/fastlane/metadata/android/en-US/changelogs/5.txt
@@ -1,0 +1,8 @@
+Bug Fixes
+
+- Fixed cursor appearing at start incase of pressing equal to button.
+- Fixed calculator losing precision after 9223372036854775807, a scientific notation is used instead.
+
+Enhancements
+
+- Converter now remembers the last section/tab you opened and the app provides a setting for this.(Settings -> Use Recent Tab). This is enabled by default.


### PR DESCRIPTION
Bug Fixes

- Fixed cursor appearing at start incase of pressing equal to button.
- Fixed calculator losing precision after 9223372036854775807, a scientific notation is used instead.

Enhancements

- Converter now remembers the last section/tab you opened and the app provides a setting for this.(Settings -> Use Recent Tab). This is enabled by default.

The following pull request fixes #16 #15 and and adds a requested feature from #14 