### PR TITLE
v1.0.5

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,14 +4,19 @@ plugins {
 }
 
 android {
+    tasks.whenTaskAdded {task ->
+        if(task.name.contains("ArtProfile")) {
+            task.enabled = false
+        }
+    }
     compileSdk 33
 
     defaultConfig {
         applicationId "yetzio.yetcalc"
         minSdk 21
         targetSdk 33
-        versionCode 5
-        versionName "1.0.4"
+        versionCode 6
+        versionName "1.0.5"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -43,11 +48,11 @@ dependencies {
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:1.2.0")
 
     implementation 'androidx.core:core-ktx:1.9.0'
-    implementation 'androidx.appcompat:appcompat:1.5.1'
+    implementation 'androidx.appcompat:appcompat:1.6.0'
     implementation 'com.google.android.material:material:1.7.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
 
-    implementation("org.mariuszgromada.math:MathParser.org-mXparser:5.0.6")
+    implementation("org.mariuszgromada.math:MathParser.org-mXparser:5.1.0")
 
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.5.1"

--- a/app/src/main/java/yetzio/yetcalc/MainActivity.kt
+++ b/app/src/main/java/yetzio/yetcalc/MainActivity.kt
@@ -455,9 +455,11 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, AdapterView.OnIt
 
         settingsLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()){
             val almInt = calculationPref.getBoolean("almostintkey", true)
+            val canInt = calculationPref.getBoolean("canonintkey", false)
             val precisionChoice = calculationPref.getString("precisionkey", "Default precision")
 
             Calc.almostInt = almInt
+            Calc.canonInt = canInt
             if (precisionChoice != null) {
                 Calc.precision = precisionChoice
             }
@@ -477,9 +479,11 @@ class MainActivity : AppCompatActivity(), View.OnClickListener, AdapterView.OnIt
     private fun initCalculationPrefs(){
         calculationPref = PreferenceManager.getDefaultSharedPreferences(this)
         val almInt = calculationPref.getBoolean("almostintkey", true)
+        val canInt = calculationPref.getBoolean("canonintkey", false)
         val precisionChoice = calculationPref.getString("precisionkey", "Default precision")
 
         Calc.almostInt = almInt
+        Calc.canonInt = canInt
         if (precisionChoice != null) {
             Calc.precision = precisionChoice
         }

--- a/app/src/main/java/yetzio/yetcalc/component/Calculator.kt
+++ b/app/src/main/java/yetzio/yetcalc/component/Calculator.kt
@@ -7,11 +7,14 @@ import org.mariuszgromada.math.mxparser.mXparser
 class Calculator{
     var angleMode = AngleMode.DEGREE
     var almostInt = true
+    var canonInt =  false
     var precision = "Default precision"
     val m_history = History()
     val MAXREP = 9999999
 
     fun calculate(expr: String): String {
+        mXparser.setUlpRounding(false)
+
         val ncr = Function("nCr(n, r) = nCk(n, r)")
         val npr = Function("nPr(n, r) = nPk(n, r)")
 
@@ -26,6 +29,11 @@ class Calculator{
             mXparser.setAlmostIntRounding(true)
         else
             mXparser.setAlmostIntRounding(false)
+
+        if(canonInt)
+            mXparser.setCanonicalRounding(true)
+        else
+            mXparser.setCanonicalRounding(false)
 
         if (angleMode == AngleMode.DEGREE) {
             mXparser.setDegreesMode()

--- a/app/src/main/java/yetzio/yetcalc/component/UnitConv.kt
+++ b/app/src/main/java/yetzio/yetcalc/component/UnitConv.kt
@@ -1,6 +1,7 @@
 package yetzio.yetcalc.component
 
 import java.math.BigDecimal
+import java.math.RoundingMode
 import kotlin.Double
 
 class UnitConv{
@@ -118,19 +119,19 @@ class UnitConv{
             }
 
             fun InchToMetre(inch: Double): Double{
-                return inch / BigDecimal("39.37").toDouble()
+                return inch * BigDecimal("0.0254").toDouble()
             }
 
             fun FeetToMetre(feet: Double): Double{
-                return feet / BigDecimal("3.281").toDouble()
+                return feet * BigDecimal("0.3048").toDouble()
             }
 
             fun YardsToMetre(yard: Double): Double{
-                return yard / BigDecimal("1.094").toDouble()
+                return yard * BigDecimal("0.9144").toDouble()
             }
 
             fun MilesToMetre(mile: Double): Double{
-                return mile * BigDecimal("1609").toDouble()
+                return mile * BigDecimal("1609.344").toDouble()
             }
 
             fun NMilesToMetre(nmile: Double): Double{
@@ -195,19 +196,19 @@ class UnitConv{
             }
 
             fun MetreToInch(metre: Double): Double{
-                return metre * BigDecimal("39.37").toDouble()
+                return BigDecimal.valueOf(metre / 0.0254).setScale(4, RoundingMode.HALF_UP).toDouble()
             }
 
             fun MetreToFeet(metre: Double): Double{
-                return metre * BigDecimal("3.281").toDouble()
+                return BigDecimal.valueOf(metre / 0.3048).setScale(4, RoundingMode.HALF_UP).toDouble()
             }
 
             fun MetreToYards(metre: Double): Double{
-                return metre * BigDecimal("1.094").toDouble()
+                return BigDecimal.valueOf(metre / 0.9144).setScale(4, RoundingMode.HALF_UP).toDouble()
             }
 
             fun MetreToMiles(metre: Double): Double{
-                return metre / BigDecimal("1609").toDouble()
+                return metre / BigDecimal("1609.344").toDouble()
             }
 
             fun MetreToNMiles(metre: Double): Double{
@@ -347,7 +348,7 @@ class UnitConv{
             }
 
             fun CupUSToCubicMetre(cup: Double): Double{
-                return cup / BigDecimal("4227").toDouble()
+                return cup / BigDecimal("4226.8").toDouble()
             }
 
             fun CupUKToCubicMetre(cup: Double): Double{
@@ -355,7 +356,7 @@ class UnitConv{
             }
 
             fun PintsUSToCubicMetre(pint: Double): Double{
-                return pint / BigDecimal("2113").toDouble()
+                return pint * BigDecimal("0.0004731765").toDouble()
             }
 
             fun PintsUKToCubicMetre(pint: Double): Double{
@@ -363,15 +364,15 @@ class UnitConv{
             }
 
             fun QuartsUSToCubicMetre(quart: Double): Double{
-                return quart / BigDecimal("1057").toDouble()
+                return quart * BigDecimal("0.0009463529").toDouble()
             }
 
             fun QuartsUKToCubicMetre(quart: Double): Double{
-                return quart / BigDecimal("879.88").toDouble()
+                return quart * BigDecimal("0.0011365225").toDouble()
             }
 
             fun GallonsUSToCubicMetre(gallon: Double): Double{
-                return gallon / BigDecimal("264.2").toDouble()
+                return gallon * BigDecimal("0.0037854118").toDouble()
             }
 
             fun GallonsUKToCubicMetre(gallon: Double): Double{
@@ -399,15 +400,15 @@ class UnitConv{
             }
 
             fun CInchesToCubicMetre(cinch: Double): Double{
-                return cinch / BigDecimal("61020").toDouble()
+                return cinch * BigDecimal("0.0000163871").toDouble()
             }
 
             fun CFeetToCubicMetre(cfeet: Double): Double{
-                return cfeet / BigDecimal("35.315").toDouble()
+                return cfeet * BigDecimal("0.0283168466").toDouble()
             }
 
             fun CYardsToCubicMetre(cyard: Double): Double{
-                return cyard / BigDecimal("1.308").toDouble()
+                return cyard * BigDecimal("0.764554858").toDouble()
             }
 
             fun TeaspoonsUSToCubicMetre(teaspoon: Double): Double{
@@ -461,7 +462,7 @@ class UnitConv{
             }
 
             fun CubicMetreToCupUS(cmetre: Double): Double{
-                return cmetre * BigDecimal("4227").toDouble()
+                return cmetre * BigDecimal("4226.8").toDouble()
             }
 
             fun CubicMetreToCupUK(cmetre: Double): Double{
@@ -469,7 +470,7 @@ class UnitConv{
             }
 
             fun CubicMetreToPintsUS(cmetre: Double): Double{
-                return cmetre * BigDecimal("2113").toDouble()
+                return cmetre / BigDecimal("0.0004731765").toDouble()
             }
 
             fun CubicMetreToPintsUK(cmetre: Double): Double{
@@ -477,15 +478,15 @@ class UnitConv{
             }
 
             fun CubicMetreToQuartsUS(cmetre: Double): Double{
-                return cmetre * BigDecimal("1057").toDouble()
+                return cmetre / BigDecimal("0.0009463529").toDouble()
             }
 
             fun CubicMetreToQuartsUK(cmetre: Double): Double{
-                return cmetre * BigDecimal("879.88").toDouble()
+                return cmetre / BigDecimal("0.0011365225").toDouble()
             }
 
             fun CubicMetreToGallonsUS(cmetre: Double): Double{
-                return cmetre * BigDecimal("264.2").toDouble()
+                return cmetre / BigDecimal("0.0037854118").toDouble()
             }
 
             fun CubicMetreToGallonsUK(cmetre: Double): Double{
@@ -513,15 +514,15 @@ class UnitConv{
             }
 
             fun CubicMetreToCInches(cinch: Double): Double{
-                return cinch * BigDecimal("61020").toDouble()
+                return cinch / BigDecimal("0.0000163871").toDouble()
             }
 
             fun CubicMetreToCFeet(cmetre: Double): Double{
-                return cmetre / BigDecimal("35.315").toDouble()
+                return cmetre / BigDecimal("0.0283168466").toDouble()
             }
 
             fun CubicMetreToCYards(cmetre: Double): Double{
-                return cmetre / BigDecimal("1.308").toDouble()
+                return cmetre / BigDecimal("0.764554858").toDouble()
             }
 
             fun CubicMetreToTeaspoonsUS(cmetre: Double): Double{

--- a/app/src/main/java/yetzio/yetcalc/model/ProgramCalcViewModel.kt
+++ b/app/src/main/java/yetzio/yetcalc/model/ProgramCalcViewModel.kt
@@ -13,4 +13,5 @@ class ProgramCalcViewModel: ViewModel(){
     var isCalcPending = false
     var prevResult = 0
     var clearInput = false
+    var divByZero = false
 }

--- a/app/src/main/java/yetzio/yetcalc/views/ProgramCalcActivity.kt
+++ b/app/src/main/java/yetzio/yetcalc/views/ProgramCalcActivity.kt
@@ -375,6 +375,12 @@ class ProgramCalcActivity : AppCompatActivity(), View.OnClickListener {
     override fun onClick(view: View?) {
         val buttonId = view?.id
 
+        if(mViewModel.divByZero){
+            tvResult.text = "0"
+            tvExp.text = "0"
+            mViewModel.divByZero = false
+        }
+
         if(buttonId != null){
             when(buttonId){
                 R.id.btnForHex -> {
@@ -593,7 +599,13 @@ class ProgramCalcActivity : AppCompatActivity(), View.OnClickListener {
             }
 
             Operator.DIV -> {
-                mViewModel.prevResult /= tvResult.text.toString().toInt(mViewModel.numberSys.radix)
+                if(tvResult.text.toString().toInt(mViewModel.numberSys.radix) == 0){
+                    mViewModel.divByZero = true
+                    mViewModel.prevResult = 0
+                }
+                else{
+                    mViewModel.prevResult /= tvResult.text.toString().toInt(mViewModel.numberSys.radix)
+                }
             }
 
             Operator.AND -> {
@@ -673,6 +685,10 @@ class ProgramCalcActivity : AppCompatActivity(), View.OnClickListener {
 
         mViewModel.textEXP = tvExp.text.toString()
         mViewModel.textRES = tvResult.text.toString()
+
+        if(mViewModel.divByZero) {
+            tvResult.text = "Cannot divide by zero!"
+        }
     }
 
     private fun setCurrentNumberSystem(numSys: NumberSystem) {
@@ -811,25 +827,25 @@ class ProgramCalcActivity : AppCompatActivity(), View.OnClickListener {
                     inputBtn3.setTextColor(ContextCompat.getColor(this, R.color.calc_textdeflight))
                 }
                 else{
-                    btnForOct.setTextColor(ContextCompat.getColor(this, R.color.calc_textdeflight))
-                    tvOct.setTextColor(ContextCompat.getColor(this, R.color.calc_textdeflight))
-                    inputBtnA.setTextColor(ContextCompat.getColor(this, R.color.greyishlight))
-                    inputBtnB.setTextColor(ContextCompat.getColor(this, R.color.greyishlight))
-                    inputBtnC.setTextColor(ContextCompat.getColor(this, R.color.greyishlight))
-                    inputBtnD.setTextColor(ContextCompat.getColor(this, R.color.greyishlight))
-                    inputBtnE.setTextColor(ContextCompat.getColor(this, R.color.greyishlight))
-                    inputBtnF.setTextColor(ContextCompat.getColor(this, R.color.greyishlight))
+                    btnForOct.setTextColor(ContextCompat.getColor(this, R.color.calc_textdef))
+                    tvOct.setTextColor(ContextCompat.getColor(this, R.color.calc_textdef))
+                    inputBtnA.setTextColor(ContextCompat.getColor(this, R.color.greyish))
+                    inputBtnB.setTextColor(ContextCompat.getColor(this, R.color.greyish))
+                    inputBtnC.setTextColor(ContextCompat.getColor(this, R.color.greyish))
+                    inputBtnD.setTextColor(ContextCompat.getColor(this, R.color.greyish))
+                    inputBtnE.setTextColor(ContextCompat.getColor(this, R.color.greyish))
+                    inputBtnF.setTextColor(ContextCompat.getColor(this, R.color.greyish))
 
-                    inputBtn7.setTextColor(ContextCompat.getColor(this, R.color.calc_textdeflight))
-                    inputBtn8.setTextColor(ContextCompat.getColor(this, R.color.greyishlight))
-                    inputBtn9.setTextColor(ContextCompat.getColor(this, R.color.greyishlight))
+                    inputBtn7.setTextColor(ContextCompat.getColor(this, R.color.calc_textdef))
+                    inputBtn8.setTextColor(ContextCompat.getColor(this, R.color.greyish))
+                    inputBtn9.setTextColor(ContextCompat.getColor(this, R.color.greyish))
 
-                    inputBtn4.setTextColor(ContextCompat.getColor(this, R.color.calc_textdeflight))
-                    inputBtn5.setTextColor(ContextCompat.getColor(this, R.color.calc_textdeflight))
-                    inputBtn6.setTextColor(ContextCompat.getColor(this, R.color.calc_textdeflight))
+                    inputBtn4.setTextColor(ContextCompat.getColor(this, R.color.calc_textdef))
+                    inputBtn5.setTextColor(ContextCompat.getColor(this, R.color.calc_textdef))
+                    inputBtn6.setTextColor(ContextCompat.getColor(this, R.color.calc_textdef))
 
-                    inputBtn2.setTextColor(ContextCompat.getColor(this, R.color.calc_textdeflight))
-                    inputBtn3.setTextColor(ContextCompat.getColor(this, R.color.calc_textdeflight))
+                    inputBtn2.setTextColor(ContextCompat.getColor(this, R.color.calc_textdef))
+                    inputBtn3.setTextColor(ContextCompat.getColor(this, R.color.calc_textdef))
                 }
 
             }

--- a/app/src/main/res/layout/fragment_unitconversions.xml
+++ b/app/src/main/res/layout/fragment_unitconversions.xml
@@ -39,7 +39,7 @@
                         android:layout_height="wrap_content"
                         android:ems="5"
                         android:hint="@string/from"
-                        android:inputType="numberDecimal"
+                        android:inputType="numberSigned|numberDecimal"
                         android:layout_marginBottom="10dp"
                         style="@style/ConvTextStyleDark"/>
 
@@ -56,7 +56,7 @@
                         android:layout_height="wrap_content"
                         android:ems="5"
                         android:hint="@string/to"
-                        android:inputType="numberDecimal"
+                        android:inputType="numberSigned|numberDecimal"
                         android:layout_marginBottom="10dp"
                         style="@style/ConvTextStyleDark"/>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <resources>
     <string name="author_name">Yet Zio</string>
     <string name="app_name">yetCalc</string>
-    <string name="VERSION_NUM">1.0.4</string>
+    <string name="VERSION_NUM">1.0.5</string>
     <string name="app_descrp">Yet another calculator by Yet Zio</string>
     <string name="ghbtext">View on GitHub</string>
     <string name="app_details">Free and open source software\nLicensed under the BSD-3-Clause license.</string>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -19,6 +19,12 @@
             app:title="Almost Integer Rounding"
             app:defaultValue="true"/>
 
+        <SwitchPreferenceCompat
+            app:key="canonintkey"
+            app:summary="Solves precision problems like 0.1 + 0.2. Enabling this might cause losing precision in really small numbers."
+            app:title="Canonical Rounding"
+            app:defaultValue="false"/>
+
         <ListPreference
             app:defaultValue="Default precision"
             app:entries="@array/precision_array"

--- a/fastlane/metadata/android/en-US/changelogs/6.txt
+++ b/fastlane/metadata/android/en-US/changelogs/6.txt
@@ -1,0 +1,9 @@
+Bug Fixes
+
+- Fixed an app crash when attempting to divide by zero in programmer mode.
+- Converter now converts feet to inches and vice versa correctly.
+- Converter now allows negative values on all sections(tabs) except currency.
+
+Enhancements
+
+- A setting to enable/disable Canonical Rounding has been added. Canonical Rounding solves issues like 0.1 + 0.2 giving invalid results. It is disabled by default. Enabling this might cause problems with calculations including really small numbers.

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -3,9 +3,9 @@ yetCalc is a Calculator with basic and scientific calculation features, a unit c
 HINT: Use landscape orientation to access scientific mode.
 
 Features: 
-- Progressive Calculations
-- Scientific Mode with trigonometric, hyperbolic and inverse functions, calculus and iterated operators, much more.
-- Unit Converter
-- Programmer Mode with number systems and logical operations.
+• Progressive Calculations
+• Scientific Mode with trigonometric, hyperbolic and inverse functions, calculus and iterated operators, much more.
+• Unit Converter
+• Programmer Mode with number systems and logical operations.
 
 NOTE: Internet connection is used for currency conversions and nothing else.


### PR DESCRIPTION
Bug Fixes

- Fixed an app crash when attempting to divide by zero in programmer mode.
- Converter now converts feet to inches and vice versa correctly.
- Converter now allows negative values on all sections(tabs) except currency.

Enhancements

- A setting to enable/disable Canonical Rounding has been added. Canonical Rounding solves issues like 0.1 + 0.2 giving invalid results. It is disabled by default. Enabling this might cause problems with calculations including really small numbers.

This pull request fixes the following issues: #20 #19 #13 