### PR TITLE
Don't include VCS info in APK

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,6 +25,7 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            vcsInfo.include false
         }
     }
     compileOptions {


### PR DESCRIPTION
ref: https://web.archive.org/web/20240401140804/https://monitor.f-droid.org/builds/log/yetzio.yetcalc/14

ref: https://gitlab.com/fdroid/fdroid-website/-/commit/e1cc123c1b97bb14fbada41a6f3165916a3a1654

~~patched in F-Droid for now: https://gitlab.com/fdroid/fdroiddata/-/commit/8ffd3e5a29863b73ee0521ba8049316bf01d35e4~~ this does not work, next version should works though