### PR TITLE
Update UnitConv.kt

### DIFF
--- a/app/src/main/java/yetzio/yetcalc/component/UnitConv.kt
+++ b/app/src/main/java/yetzio/yetcalc/component/UnitConv.kt
@@ -967,12 +967,12 @@ class UnitConv{
                 return ounce / BigDecimal("35.274").toDouble()
             }
 
-            fun PoundsToKiloG(pound: Double): Double{
-                return pound / BigDecimal("2.205").toDouble()
+            fun PoundsToKiloG(pound: Double): Double {
+                return pound * 0.45359237
             }
 
-            fun StonesToKiloG(stone: Double): Double{
-                return stone * BigDecimal("6.35").toDouble()
+            fun StonesToKiloG(stone: Double): Double {
+                return stone * 6.35029318
             }
 
             fun TonsUSToKiloG(ton: Double): Double{
@@ -1061,12 +1061,12 @@ class UnitConv{
                 return kilog * BigDecimal("35.274").toDouble()
             }
 
-            fun KiloGToPounds(kilog: Double): Double{
-                return kilog * BigDecimal("2.205").toDouble()
+            fun KiloGToPounds(kilog: Double): Double {
+                return kilog / 0.45359237
             }
 
-            fun KiloGToStones(kilog: Double): Double{
-                return kilog / BigDecimal("6.35").toDouble()
+            fun KiloGToStones(kilog: Double): Double {
+                return kilog / 6.35029318
             }
 
             fun KiloGToTonsUS(kilog: Double): Double{
@@ -2580,4 +2580,5 @@ class UnitConv{
             }
         }
     }
+
 }


### PR DESCRIPTION
Bug Fix: Corrected Conversion Constants for Pounds and Stones
Fixes #199
Summary
The conversion constants for stones and pounds were slightly inaccurate in the existing implementation, leading to small rounding errors in weight conversions.

Details

Old constants:

1 pound = 0.4535147392290249 kg

1 stone = 6.35 kg

Correct constants (ISO/NIST standard):

1 pound = 0.45359237 kg

1 stone = 6.35029318 kg

Fix Implemented

Updated both constants to their exact values.

Verified that 1 stone now correctly converts to exactly 14 pounds (previously 14.00175 lb).

Result

This fix ensures:

Accurate conversion between stones, pounds, and kilograms.

Improved numerical consistency across all related calculations.

Tested

Unit conversions validated manually and through existing tests.

Confirmed no breaking changes introduced.


