### PR TITLE
Added the ability to disable scientific notation in calculation results

### DIFF
--- a/app/src/main/java/yetzio/yetcalc/component/Calculator.kt
+++ b/app/src/main/java/yetzio/yetcalc/component/Calculator.kt
@@ -9,6 +9,7 @@ class Calculator{
     var angleMode = AngleMode.DEGREE
     var almostInt = true
     var canonInt =  false
+    var disableScientificNotation =  false
     var precision = "Default precision"
     val m_history = History()
     val MAXREP = 9999999
@@ -49,15 +50,23 @@ class Calculator{
 
         val e = Expression(expr, grad, npr, ncr)
 
-
-        return if(e.calculate() > MAXREP){
-            e.calculate().toString()
+        val calcRes = e.calculate()     //resource intensive, save first
+        return if(calcRes.isNaN() || calcRes.isInfinite()){
+            // invalid expression returns NaN, or result too big
+            // cannot be converted into BigDecimal
+            calcRes.toString()
         }
-        else if(e.calculate() % 1.0 == 0.0){
-            Math.round(e.calculate()).toString()
+        else if(calcRes < MAXREP && e.calculate() % 1.0 == 0.0){
+            if (disableScientificNotation)
+                Math.round(calcRes).toBigDecimal().stripTrailingZeros().toPlainString()
+            else
+                Math.round(calcRes).toString()
         }
         else{
-            e.calculate().toString()
+            if (disableScientificNotation)
+                calcRes.toBigDecimal().stripTrailingZeros().toPlainString()
+            else
+                calcRes.toString()
         }
     }
 

--- a/app/src/main/java/yetzio/yetcalc/component/SharedPrefs.kt
+++ b/app/src/main/java/yetzio/yetcalc/component/SharedPrefs.kt
@@ -15,6 +15,7 @@ object SharedPrefs {
     const val DATEHISTKEY = "datehistkey"
     const val ALMINTKEY = "almostintkey"
     const val CANINTKEY = "canonintkey"
+    const val DISABLESCINOTATIONKEY = "disablescinotationkey"
     const val PRECKEY = "precisionkey"
     const val HAPTICKEY = "hapticfdkey"
     const val LEFTJUSTRES = "leftjustifyres"

--- a/app/src/main/java/yetzio/yetcalc/views/CalculatorActivity.kt
+++ b/app/src/main/java/yetzio/yetcalc/views/CalculatorActivity.kt
@@ -306,11 +306,13 @@ class CalculatorActivity : CalcBaseActivity(), View.OnClickListener {
 
             val almInt = preferences.getBoolean(SharedPrefs.ALMINTKEY, true)
             val canInt = preferences.getBoolean(SharedPrefs.CANINTKEY, false)
+            val disableScientificNotation = preferences.getBoolean(SharedPrefs.DISABLESCINOTATIONKEY, false)
             val precisionChoice = preferences.getString(SharedPrefs.PRECKEY, "Default precision")
             mviewModel.hapticPref = preferences.getBoolean(SharedPrefs.HAPTICKEY, true)
 
             Calc.almostInt = almInt
             Calc.canonInt = canInt
+            Calc.disableScientificNotation = disableScientificNotation
             if (precisionChoice != null) {
                 Calc.precision = precisionChoice
             }
@@ -367,10 +369,12 @@ class CalculatorActivity : CalcBaseActivity(), View.OnClickListener {
     private fun initCalculationPrefs(){
         val almInt = preferences.getBoolean(SharedPrefs.ALMINTKEY, true)
         val canInt = preferences.getBoolean(SharedPrefs.CANINTKEY, false)
+        val disableScientificNotation = preferences.getBoolean(SharedPrefs.DISABLESCINOTATIONKEY, false)
         val precisionChoice = preferences.getString(SharedPrefs.PRECKEY, "Default precision")
 
         Calc.almostInt = almInt
         Calc.canonInt = canInt
+        Calc.disableScientificNotation = disableScientificNotation
         if (precisionChoice != null) {
             Calc.precision = precisionChoice
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1147,6 +1147,9 @@
     <string name="canonicalrtitle">Canonical Rounding</string>
     <string name="canonicalrsubtext">Solves precision problems like 0.1 + 0.2. Enabling this might cause losing precision in really small numbers</string>
 
+    <string name="disablescinotrtitle">Disable Scientific Notation</string>
+    <string name="disablescinotrsubtext">If toggled, calculation results are never converted into scientific notation</string>
+
     <string name="datehisttitle">Date History Format</string>
     <string name="datehistrsubtext">Select your desired date format for history</string>
 

--- a/app/src/main/res/xml/calcpref.xml
+++ b/app/src/main/res/xml/calcpref.xml
@@ -37,6 +37,13 @@
         app:title="@string/canonicalrtitle"
         app:defaultValue="false"/>
 
+    <SwitchPreferenceCompat
+        app:key="disablescinotationkey"
+        android:icon="@drawable/round_123_24"
+        app:summary="@string/disablescinotrsubtext"
+        app:title="@string/disablescinotrtitle"
+        app:defaultValue="false"/>
+
     <androidx.preference.Preference
         android:key="datetimeformat"
         app:icon="@drawable/round_view_timeline_24"


### PR DESCRIPTION
Scientific notation can now be disbled with a toggle in settings >> Calculator >> Disable scientific notation
this closes issue #215 as an enhancement